### PR TITLE
unparse.js: fix UMD header for browser compatibility.

### DIFF
--- a/lib/unparse.js
+++ b/lib/unparse.js
@@ -1,12 +1,10 @@
 (function(root, factory) {
     if (typeof module === 'object' && module.exports) {
-        module.exports = factory(require('./nearley'));
+        module.exports = factory(require('./nearley'), require('randexp'));
     } else {
-        root.Unparser = factory(root.nearley);
+        root.Unparser = factory(root.nearley, root.RandExp);
     }
-}(this, function(nearley) {
-
-    var randexp = require('randexp');
+}(this, function(nearley, randexp) {
 
     function genRandom(grammar, start) {
         // The first-generation generator. It just spews out stuff randomly, and is


### PR DESCRIPTION
The existing file uses a mix of UMD and CommonJS for dependencies. This moves both dependencies to UMD so it can be dropped into a browser.

Note that randexp does ship a browser-compatible bundle, but only minified, and it exports under the name `RandExp`, not `randexp`.